### PR TITLE
Fixed ProcessID variable getting passed into 32-bit PowerShell from 64-bit PowerShell

### DIFF
--- a/CodeExecution/Invoke--Shellcode.ps1
+++ b/CodeExecution/Invoke--Shellcode.ps1
@@ -1,5 +1,4 @@
-﻿
-function Invoke-Shellcode
+﻿function Invoke-Shellcode
 {
 <#
 .SYNOPSIS

--- a/CodeExecution/Invoke--Shellcode.ps1
+++ b/CodeExecution/Invoke--Shellcode.ps1
@@ -1,4 +1,5 @@
-﻿function Invoke-Shellcode
+﻿
+function Invoke-Shellcode
 {
 <#
 .SYNOPSIS

--- a/CodeExecution/Invoke--Shellcode.ps1
+++ b/CodeExecution/Invoke--Shellcode.ps1
@@ -1,4 +1,4 @@
-function Invoke-Shellcode
+﻿function Invoke-Shellcode
 {
 <#
 .SYNOPSIS
@@ -546,8 +546,9 @@ http://www.exploit-monday.com
             # The currently supported Metasploit payloads are 32-bit. This block of code implements the logic to execute this script from 32-bit PowerShell
             # Get this script's contents and pass it to 32-bit powershell with the same parameters passed to this function
 
-            # Pull out just the content of the this script's invocation.
-            $RootInvocation = $MyInvocation.Line
+            # Pull out just the content of the this script's invocation and replace the $ProcessId variable with its value.
+            # (Invoke-Expression won't pass the variable into the 32-bit instance of PowerShell)
+            $RootInvocation = $MyInvocation.Line -replace '(?<=\-ProcessID\s)([^\s]+)',$ProcessId
 
             $Response = $True
         


### PR DESCRIPTION
I was looking to implement this code when I found a bug/odd behaviour.

#### Bug 
When the script is started in a 64-bit PowerShell session, Invoke-Expression will pass the script into a 32-bit instance of PowerShell. However, if the `-ProcessID` value is specified it doesn't get passed into the new session and the variable is blank. This prevents the shellcode from getting inserted into the targeted process.

#### Update/Fix
Fixed by adding a regular expression to replace the `ProcessID` variable with its value. This will pass the value into the 32-bit session successfully, and will **NOT** break if no `-ProcessID` is provided.
```powershell
$RootInvocation = $MyInvocation.Line -replace '(?<=\-ProcessID\s)([^\s]+)',$ProcessId
```

@PowerShellMafia Let me know what you think and if you need me to make any changes!!
