### PR TITLE
Update Invoke-TokenManipulation.ps1

### DIFF
--- a/Exfiltration/Invoke-TokenManipulation.ps1
+++ b/Exfiltration/Invoke-TokenManipulation.ps1
@@ -1691,8 +1691,6 @@ Blog on this script: http://clymb3r.wordpress.com/2013/11/03/powershell-and-toke
         ForEach ($SystemToken in $SystemTokens)
         {
             $SystemTokenInfo = Get-PrimaryToken -ProcessId $SystemToken.Id -WarningAction SilentlyContinue -ErrorAction SilentlyContinue
-            $SystemProcessName = $SystemToken.Name
-            $SystemProcessID = $SystemToken.Id
         }
         if ($systemTokenInfo -eq $null -or (-not (Invoke-ImpersonateUser -hToken $systemTokenInfo.hProcToken)))
         {


### PR DESCRIPTION
Re-opening pull request to dev branch instead of master at request.

Windows 10 breaks the current version of Invoke-TokenManipulation.ps1 because wininit is now a protected processes. Rather than hardcoding to a specific process to obtain a SYSTEM token, it's better to enumerate all processes running as SYSTEM and find one that works. I have updated the script to version 1.12 and added logic on lines 1689-1694 to make sure it can successfully grab a SYSTEM token necessary to function