### PR TITLE
Fix 'Install-ServiceBinary' for non-'Modifiable' files

### DIFF
--- a/Privesc/PowerUp.ps1
+++ b/Privesc/PowerUp.ps1
@@ -794,7 +794,7 @@ function Write-ServiceBinary {
 
         The service name the EXE will be running under. Required.
 
-    .PARAMETER Path
+    .PARAMETER ServicePath
 
         Path to write the binary out to, defaults to the local directory.
 
@@ -920,7 +920,7 @@ function Install-ServiceBinary {
 <#
     .SYNOPSIS
 
-        Users Write-ServiceBinary to write a C# service that creates a local UserName
+        Uses Write-ServiceBinary to write a C# service that creates a local UserName
         and adds it to specified LocalGroup or executes a custom command.
         Domain users are only added to the specified LocalGroup.
 
@@ -1006,7 +1006,7 @@ function Install-ServiceBinary {
 
                 Write-Verbose "Backing up '$ServicePath' to '$BackupPath'"
                 try {
-                    Move-Item -Path $ServicePath -Destination $BackupPath -Force
+                    Copy-Item -Path $ServicePath -Destination $BackupPath -Force
                 }
                 catch {
                     Write-Warning "[*] Original path '$ServicePath' for '$ServiceName' does not exist!"


### PR DESCRIPTION
The 'Install-ServiceBinary' function does not cater for an edge case where the
service's file permission does not include the 'Modify' permission but
does include the 'Write' permission
(https://technet.microsoft.com/en-au/library/dd349321(v=ws.10).aspx). In
this scenario, renaming the original service file for backup purposes
will result in an 'Access Denied' message. Fixing this requires that the
file be copied to service.exe.bak instead of renamed to service.exe.bak.