### PR TITLE
Find-PathHijack: Expand environment variables in path

### DIFF
--- a/Privesc/PowerUp.ps1
+++ b/Privesc/PowerUp.ps1
@@ -1283,6 +1283,7 @@ function Find-PathHijack {
         if (-not $Path.EndsWith("\")){
             $Path = $Path + "\"
         }
+        $Path = [System.Environment]::ExpandEnvironmentVariables($Path)
 
         # reference - http://stackoverflow.com/questions/9735449/how-to-verify-whether-the-share-has-write-access
         $TestPath = Join-Path $Path ([IO.Path]::GetRandomFileName())


### PR DESCRIPTION
Paths containing environment variables can cause false-positives to occur, e.g. `%SystemRoot%\system32\WindowsPowerShell\v1.0\`. `Find-PathHijack` will believe this is a relative path and will report it as hijackable if the current directory is writeable.