### PR TITLE
//Group -> //Groups

### DIFF
--- a/Recon/PowerView.ps1
+++ b/Recon/PowerView.ps1
@@ -5440,7 +5440,7 @@ function Get-GroupsXML {
             $FolderPath = $Parts[0..($Parts.length-2)] -join '\'
             $FilePath = $Parts[-1]
             $RandDrive = ("abcdefghijklmnopqrstuvwxyz".ToCharArray() | Get-Random -Count 7) -join ''
-            
+
             Write-Verbose "Mounting path $GroupsXMLPath using a temp PSDrive at $RandDrive"
 
             try {
@@ -5462,7 +5462,7 @@ function Get-GroupsXML {
             [xml] $GroupsXMLcontent = Get-Content $GroupsXMLPath -ErrorAction Stop
 
             # process all group properties in the XML
-            $GroupsXMLcontent | Select-Xml "//Group" | Select-Object -ExpandProperty node | ForEach-Object {
+            $GroupsXMLcontent | Select-Xml "//Groups" | Select-Object -ExpandProperty node | ForEach-Object {
 
                 $Members = @()
                 $MemberOf = @()


### PR DESCRIPTION
The XML I see has `Groups` not `Group`

Additionally the rest of the logic seems b0rked as the $_ doesn't have Properties...

```
[DBG]: PS C:\Users\Administrator>> $_

clsid                                                         User                                                          Group                                                        
-----                                                         ----                                                          -----                                                        
{3125E937-EB16-4b4c-9934-544FC6D24D26}                        User                                                          Group                                                        



[DBG]: PS C:\Users\Administrator>> $_.Properties

[DBG]: PS C:\Users\Administrator>> $_.User


clsid        : {DF5F1855-51E5-4d24-8B1A-D9BDE98BA1D1}
name         : Administrator
image        : 2
changed      : 2016-04-12 09:10:51
uid          : {1990D088-F99A-4D4D-B78A-87273627CD39}
userContext  : 0
removePolicy : 0
Properties   : Properties




[DBG]: PS C:\Users\Administrator>> $_.User.Properties


action       : U
newName      : 
fullName     : 
description  : 
cpassword    : Mwrt1Yk7tdo9JNrX24J1yVqUgk98ze4fyZ9aIg4pYDM
changeLogon  : 0
noChange     : 1
neverExpires : 1
acctDisabled : 0
userName     : Administrator
```