### PR TITLE
Retrieve Domain SIDs with -LDAP

### DIFF
--- a/Recon/PowerView.ps1
+++ b/Recon/PowerView.ps1
@@ -12309,6 +12309,7 @@ function Get-NetDomainTrust {
         if($LDAP -or $DomainController) {
 
             $TrustSearcher = Get-DomainSearcher -Domain $Domain -DomainController $DomainController -Credential $Credential -PageSize $PageSize
+            $SourceSID = Get-DomainSID -Domain $Domain -DomainController $DomainController
 
             if($TrustSearcher) {
 
@@ -12341,8 +12342,11 @@ function Get-NetDomainTrust {
                         3 { "Bidirectional" }
                     }
                     $ObjectGuid = New-Object Guid @(,$Props.objectguid[0])
+                    $TargetSID = (New-Object System.Security.Principal.SecurityIdentifier($Props.securityidentifier[0],0)).Value
                     $DomainTrust | Add-Member Noteproperty 'SourceName' $Domain
+                    $DomainTrust | Add-Member Noteproperty 'SourceSID' $SourceSID
                     $DomainTrust | Add-Member Noteproperty 'TargetName' $Props.name[0]
+                    $DomainTrust | Add-Member Noteproperty 'TargetSID' $TargetSID
                     $DomainTrust | Add-Member Noteproperty 'ObjectGuid' "{$ObjectGuid}"
                     $DomainTrust | Add-Member Noteproperty 'TrustType' "$TrustAttrib"
                     $DomainTrust | Add-Member Noteproperty 'TrustDirection' "$Direction"
@@ -12854,7 +12858,9 @@ function Invoke-MapDomainTrust {
                         # build the nicely-parsable custom output object
                         $DomainTrust = New-Object PSObject
                         $DomainTrust | Add-Member Noteproperty 'SourceDomain' "$SourceDomain"
+                        $DomainTrust | Add-Member Noteproperty 'SourceSID' $Trust.SourceSID
                         $DomainTrust | Add-Member Noteproperty 'TargetDomain' "$TargetDomain"
+                        $DomainTrust | Add-Member Noteproperty 'TargetSID' $Trust.TargetSID
                         $DomainTrust | Add-Member Noteproperty 'TrustType' "$TrustType"
                         $DomainTrust | Add-Member Noteproperty 'TrustDirection' "$TrustDirection"
                         $DomainTrust


### PR DESCRIPTION
Retrieves SIDs for `Get-NetDomainTrust` and `Invoke-MapDomainTrust` methods when using -LDAP.

Not sure how to use it for the default scenario without doing additional calls - are you sure this isn't using LDAP to retrieve it anyway, considering it is a method on the `DirectoryServices.ActiveDirectory.Domain/Forest` objects?