### PR TITLE
PowerView - Fix Groups.xml Parsing

### DIFF
--- a/Recon/PowerView.ps1
+++ b/Recon/PowerView.ps1
@@ -6091,7 +6091,7 @@ function Get-GroupsXML {
 
             # so we can cd/dir the new drive
             $GroupsXMLPath = $RandDrive + ":\" + $FilePath
-        } 
+        }
     }
 
     process {
@@ -6106,21 +6106,21 @@ function Get-GroupsXML {
                 $MemberOf = @()
 
                 # extract the localgroup sid for memberof
-                $LocalSid = $_.Properties.GroupSid
+                $LocalSid = $_.Group.Properties.GroupSid
                 if(!$LocalSid) {
-                    if($_.Properties.groupName -match 'Administrators') {
+                    if($_.Group.Properties.groupName -match 'Administrators') {
                         $LocalSid = 'S-1-5-32-544'
                     }
-                    elseif($_.Properties.groupName -match 'Remote Desktop') {
+                    elseif($_.Group.Properties.groupName -match 'Remote Desktop') {
                         $LocalSid = 'S-1-5-32-555'
                     }
                     else {
-                        $LocalSid = $_.Properties.groupName
+                        $LocalSid = $_.Group.Properties.groupName
                     }
                 }
                 $MemberOf = @($LocalSid)
 
-                $_.Properties.members | ForEach-Object {
+                $_.Group.Properties.members | ForEach-Object {
                     # process each member of the above local group
                     $_ | Select-Object -ExpandProperty Member | Where-Object { $_.action -match 'ADD' } | ForEach-Object {
 
@@ -6143,16 +6143,38 @@ function Get-GroupsXML {
                     }
 
                     if($ResolveSids) {
-                        $Memberof = $Memberof | ForEach-Object {Convert-SidToName $_}
-                        $Members = $Members | ForEach-Object {Convert-SidToName $_}
+                        $Memberof = $Memberof | ForEach-Object {
+                            $memof = $_
+                            if ($memof.StartsWith("S-1-"))
+                            {
+                                try {
+                                    Convert-SidToName $memof
+                                } catch {
+                                    $memof
+                                }
+                            } else {
+                                $memof
+                            }
+                        }
+                        $Members= $Members | ForEach-Object {
+                            $member = $_
+                            if ($member.StartsWith("S-1-"))
+                            {
+                                try {
+                                    Convert-SidToName $member
+                                } catch {
+                                    $member
+                                }
+                            } else {
+                                $member
+                            }
+                        }
                     }
 
                     if($Memberof -isnot [system.array]) {$Memberof = @($Memberof)}
                     if($Members -isnot [system.array]) {$Members = @($Members)}
 
                     $GPOProperties = @{
-                        'GPODisplayName' = $GPODisplayName
-                        'GPOName' = $GPOName
                         'GPOPath' = $GroupsXMLPath
                         'Filters' = $Filters
                         'MemberOf' = $Memberof


### PR DESCRIPTION
Few issues, it tries to reference `$_.Properties` but Properties only exists on `$_.User` or `$_.Group`. 

Secondly if you try to resolve sids but pass a non-sid value it hits an exception and dies silently. 

Thirdly the PSObject tries to return two values we have no knowledge/concept of in the function.

Working off the following XML:

```
<?xml version="1.0" encoding="UTF-8"?>

-<Groups clsid="{3125E937-EB16-4b4c-9934-544FC6D24D26}">


-<User clsid="{DF5F1855-51E5-4d24-8B1A-D9BDE98BA1D1}" removePolicy="0" userContext="0" uid="{1990D088-F99A-4D4D-B78A-87273627CD39}" changed="2016-04-12 09:10:51" image="2" name="Administrator">

<Properties userName="Administrator" acctDisabled="0" neverExpires="1" noChange="1" changeLogon="0" cpassword="Mwrt1Yk7tdo9JNrX24J1yVqUgk98ze4fyZ9aIg4pYDM" description="" fullName="" newName="" action="U"/>

</User>


-<Group clsid="{6D4A79E4-529C-4481-ABD0-F5BD7EA93BA7}" uid="{C736C52C-7711-4129-88D4-EC8792938482}" changed="2016-04-12 13:27:30" image="2" name="Administrators">


-<Properties description="" newName="" action="U" groupName="Administrators" removeAccounts="0" deleteAllGroups="0" deleteAllUsers="0">


-<Members>

<Member name="Bob" action="ADD" sid=""/>

</Members>

</Properties>

</Group>

</Groups>
```