### PR TITLE
Fix Get-NetLocalGroup Recursion for LocalGroups 

### DIFF
--- a/Recon/PowerView.ps1
+++ b/Recon/PowerView.ps1
@@ -7722,7 +7722,7 @@ function Get-NetLocalGroup {
                         $Offset += $Increment
 
                         $SidString = ""
-                        $Result2 = $Advapi32::ConvertSidToStringSid($Info.lgrmi2_sid, [ref]$SidString);$LastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error
+                        $Result2 = $Advapi32::ConvertSidToStringSid($Info.lgrmi2_sid, [ref]$SidString);$LastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
 
                         if($Result2 -eq 0) {
                             Write-Verbose "Error: $(([ComponentModel.Win32Exception] $LastError).Message)"


### PR DESCRIPTION
Check class type
Recurse if localgroup as well as domaingroup
Normalize output values to empty string

managed to merge it in with dev changes :cry: 