### PR TITLE
PowerView: Fix Groups.xml parsing for multiple <Group>s

### DIFF
--- a/Recon/PowerView.ps1
+++ b/Recon/PowerView.ps1
@@ -6141,12 +6141,12 @@ filter Get-GroupsXML {
         [XML]$GroupsXMLcontent = Get-Content $TargetGroupsXMLPath -ErrorAction Stop
 
         # process all group properties in the XML
-        $GroupsXMLcontent | Select-Xml "//Groups" | Select-Object -ExpandProperty node | ForEach-Object {
+        $GroupsXMLcontent | Select-Xml "/Groups/Group" | Select-Object -ExpandProperty node | ForEach-Object {
 
-            $Groupname = $_.Group.Properties.groupName
+            $Groupname = $_.Properties.groupName
 
             # extract the localgroup sid for memberof
-            $GroupSID = $_.Group.Properties.GroupSid
+            $GroupSID = $_.Properties.groupSid
             if(-not $LocalSid) {
                 if($Groupname -match 'Administrators') {
                     $GroupSID = 'S-1-5-32-544'
@@ -6163,7 +6163,7 @@ filter Get-GroupsXML {
             }
 
             # extract out members added to this group
-            $Members = $_.Group.Properties.members | Select-Object -ExpandProperty Member | Where-Object { $_.action -match 'ADD' } | ForEach-Object {
+            $Members = $_.Properties.members | Select-Object -ExpandProperty Member | Where-Object { $_.action -match 'ADD' } | ForEach-Object {
                 if($_.sid) { $_.sid }
                 else { $_.name }
             }
@@ -6171,8 +6171,8 @@ filter Get-GroupsXML {
             if ($Members) {
 
                 # extract out any/all filters...I hate you GPP
-                if($_.Group.filters) {
-                    $Filters = $_.Group.filters.GetEnumerator() | ForEach-Object {
+                if($_.filters) {
+                    $Filters = $_.filters.GetEnumerator() | ForEach-Object {
                         New-Object -TypeName PSObject -Property @{'Type' = $_.LocalName;'Value' = $_.name}
                     }
                 }

--- a/Recon/PowerView.ps1
+++ b/Recon/PowerView.ps1
@@ -6147,7 +6147,7 @@ filter Get-GroupsXML {
 
             # extract the localgroup sid for memberof
             $GroupSID = $_.Properties.groupSid
-            if(-not $LocalSid) {
+            if(-not $GroupSID) {
                 if($Groupname -match 'Administrators') {
                     $GroupSID = 'S-1-5-32-544'
                 }


### PR DESCRIPTION
`Get-GroupsXML` fails to parse Groups.xml files with multiple `<Group>` nodes.

Here is a stripped down Groups.xml file as an example:

    <?xml version="1.0" encoding="utf-8"?>
    <Groups>
    	<Group><Properties groupSid="S-1-5-32-544" groupName="Administrators (built-in)"><Members><Member name="SomeUser" action="ADD" sid=""/></Members></Properties><Filters/></Group>
    	<Group><Properties groupName="SomeGroup"><Members><Member name="SomeUser" action="ADD" sid=""/></Members></Properties></Group>
    	<Group><Properties groupName="AnotherGroup"><Members><Member name="SomeUser" action="ADD" sid=""/></Members></Properties></Group>
    </Groups>

Current behaviour:

    PS > Get-GroupsXML .\Groups.xml -Verbose
    VERBOSE: Error parsing .\Groups.xml : Cannot bind argument to parameter 'ObjectName' because it is an empty string.

With the fix:

    PS > Get-GroupsXML .\Groups.xml -Verbose

    GPOPath       : .\test.xml
    Filters       :
    GroupName     : Administrators (built-in)
    GroupSID      : S-1-5-32-544
    GroupMemberOf :
    GroupMembers  : {SomeUser}

    GPOPath       : .\test.xml
    Filters       :
    GroupName     : SomeGroup
    GroupSID      :
    GroupMemberOf :
    GroupMembers  : {SomeUser}

    GPOPath       : .\test.xml
    Filters       :
    GroupName     : AnotherGroup
    GroupSID      :
    GroupMemberOf :
    GroupMembers  : {SomeUser}

Second commit completes a variable rename which was missed in a previous refactor (f6ee5cb92ee7c037e57f5b09bc01340efea59283).