### PR TITLE
PowerUp: Allocate enough space for TOKEN_GROUPS

### DIFF
--- a/Privesc/PowerUp.ps1
+++ b/Privesc/PowerUp.ps1
@@ -974,17 +974,16 @@ function Get-CurrentUserTokenGroupSid {
     $Success = $Advapi32::OpenProcessToken($CurrentProcess, $TOKEN_QUERY, [ref]$hProcToken);$LastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
 
     if($Success) {
-
-        $TokenGroupsPtrSize = $TOKEN_GROUPS::GetSize()
+        $TokenGroupsPtrSize = 0
+        # Initial query to determine the necessary buffer size
+        $Success = $Advapi32::GetTokenInformation($hProcToken, 2, 0, $TokenGroupsPtrSize, [ref]$TokenGroupsPtrSize)
 
         [IntPtr]$TokenGroupsPtr = [System.Runtime.InteropServices.Marshal]::AllocHGlobal($TokenGroupsPtrSize)
 
-        [UInt32]$RealSize = 0
-
         # query the current process token with the 'TokenGroups=2' TOKEN_INFORMATION_CLASS enum to retrieve a TOKEN_GROUPS structure
-        $Success2 = $Advapi32::GetTokenInformation($hProcToken, 2, $TokenGroupsPtr, $TokenGroupsPtrSize, [ref]$TokenGroupsPtrSize);$LastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+        $Success = $Advapi32::GetTokenInformation($hProcToken, 2, $TokenGroupsPtr, $TokenGroupsPtrSize, [ref]$TokenGroupsPtrSize);$LastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
 
-        if($Success2) {
+        if($Success) {
 
             $TokenGroups = $TokenGroupsPtr -as $TOKEN_GROUPS
 


### PR DESCRIPTION
Make an initial call to GetTokenInformation() with a NULL buffer to get the actual buffer size required. Prevents "The data area passed to a system call is too small" error being thrown.

Current implementation raises the following warning:

    PS > Get-CurrentUserTokenGroupSid
    WARNING: System.ComponentModel.Win32Exception (0x80004005): The data area passed to a system call is too small