### PR TITLE
PowerUp: Remove badly encoded new lines from .bat output

### DIFF
--- a/Privesc/PowerUp.ps1
+++ b/Privesc/PowerUp.ps1
@@ -2669,8 +2669,8 @@ function Write-HijackDll {
     # build the launcher .bat
     if (Test-Path $TargetBatPath) { Remove-Item -Force $TargetBatPath }
 
-    "@echo off\n" | Out-File -Encoding ASCII -Append $TargetBatPath
-    "start /b $BatCommand\n" | Out-File -Encoding ASCII -Append $TargetBatPath
+    "@echo off" | Out-File -Encoding ASCII -Append $TargetBatPath
+    "start /b $BatCommand" | Out-File -Encoding ASCII -Append $TargetBatPath
     'start /b "" cmd /c del "%~f0"&exit /b' | Out-File -Encoding ASCII -Append $TargetBatPath
 
     Write-Verbose ".bat launcher written to: $TargetBatPath"


### PR DESCRIPTION
The current implementation results in a .bat like:

    @echo off\n
    start /b net user john Password123! /add && timeout /t 5 && net localgroup Administrators john /add\n
    start /b "" cmd /c del "%~f0"&exit /b

With literal "\n" strings at the end of the first two lines.

A new line in a PowerShell string should be "`n". However, an extra new line isn't actually necessary in this case.