### PR TITLE
Service DACL false positive | Request-SPNTicket double hash

### DIFF
--- a/Privesc/PowerUp.ps1
+++ b/Privesc/PowerUp.ps1
@@ -1404,7 +1404,7 @@ function Test-ServiceDaclPermission {
                         else {
                             ForEach($TargetPermission in $TargetPermissions) {
                                 # check permissions || style
-                                if (($ServiceDacl.AccessRights -band $AccessMask[$TargetPermission]) -eq $AccessMask[$TargetPermission]) {
+                                if (($ServiceDacl.AceType -eq 'AccessAllowed') -and ($ServiceDacl.AccessRights -band $AccessMask[$TargetPermission]) -eq $AccessMask[$TargetPermission]) {
                                     Write-Verbose "Current user has '$TargetPermission' for $IndividualService"
                                     $TargetService
                                     break

--- a/Recon/PowerView.ps1
+++ b/Recon/PowerView.ps1
@@ -1382,6 +1382,7 @@ function Request-SPNTicket {
                     [System.Collections.ArrayList]$Parts = ($TicketHexStream -replace '^(.*?)04820...(.*)','$2') -Split "A48201"
                     $Parts.RemoveAt($Parts.Count - 1)
                     $Parts -join "A48201"
+                    break
                 }
             }
         }


### PR DESCRIPTION
Some DACLs are explicit denies instead of explicit allows. We need to check the AceType first, otherwise 'AccessDenied' will provide a false positive that the service is vulnerable.

<3
- Nick