### PR TITLE
Fixed path variable name

### DIFF
--- a/Privesc/PowerUp.ps1
+++ b/Privesc/PowerUp.ps1
@@ -462,7 +462,7 @@ function Get-ServiceUnquoted {
             $Out | Add-Member Noteproperty 'ServiceName' $Service.name
             $Out | Add-Member Noteproperty 'Path' $Service.pathname
             $Out | Add-Member Noteproperty 'StartName' $Service.startname
-            $Out | Add-Member Noteproperty 'AbuseFunction' "Write-ServiceBinary -ServiceName '$($Service.name)' -Path <HijackPath>"
+            $Out | Add-Member Noteproperty 'AbuseFunction' "Write-ServiceBinary -ServiceName '$($Service.name)' -ServicePath <HijackPath>"
             $Out
         }
     }
@@ -794,7 +794,7 @@ function Write-ServiceBinary {
 
         The service name the EXE will be running under. Required.
 
-    .PARAMETER Path
+    .PARAMETER ServicePath
 
         Path to write the binary out to, defaults to the local directory.
 


### PR DESCRIPTION
PowerUp displays to the console that the user needs to provide the "Path" Command line option (and path is referenced when providing information about the command line options), however the actual script relies on the variable "ServicePath" (lines 902, 905, 912).