### PR TITLE
Add disabled and present searches to get-netfileservers

### DIFF
--- a/Recon/PowerView.ps1
+++ b/Recon/PowerView.ps1
@@ -5642,13 +5642,13 @@ function Get-NetFileServer {
             }
         }
     }
-
-    Get-NetUser -Domain $Domain -DomainController $DomainController -Credential $Credential -PageSize $PageSize | Where-Object {$_} | Where-Object {
+    $filter = "(!(userAccountControl:1.2.840.113556.1.4.803:=2))(|(scriptpath=*)(homedirectory=*)(profilepath=*))"
+    Get-NetUser -Domain $Domain -DomainController $DomainController -Credential $Credential -PageSize $PageSize -Filter $filter | Where-Object {$_} | Where-Object {
             # filter for any target users
             if($TargetUsers) {
                 $TargetUsers -Match $_.samAccountName
             }
-            else { $True } 
+            else { $True }
         } | ForEach-Object {
             # split out every potential file server path
             if($_.homedirectory) {


### PR DESCRIPTION
Don't search through disabled accounts for file servers, and only retrieve results where the scriptpath/homedirectory/profilepath fields are present. Hopefully speed up searches and improve performance of Invoke-UserHunter in large domains?