### PR TITLE
Fix errors gathering the forest SID

### DIFF
--- a/Recon/PowerView.ps1
+++ b/Recon/PowerView.ps1
@@ -3891,10 +3891,10 @@ to the forest root domain SID.
         if ($ForestObject) {
             # get the SID of the forest root
             if ($PSBoundParameters['Credential']) {
-                $ForestSid = ConvertTo-SID -ObjectName "krbtgt@$($ForestObject.RootDomain)" -Credential $Credential
+                $ForestSid = (Get-DomainUser -Identity "krbtgt" -Domain $ForestObject.RootDomain.Name -Credential $Credential).objectsid
             }
             else {
-                $ForestSid = ConvertTo-SID -ObjectName "krbtgt@$($ForestObject.RootDomain)"
+                $ForestSid = (Get-DomainUser -Identity "krbtgt" -Domain $ForestObject.RootDomain.Name).objectsid
             }
 
             $Parts = $ForestSid -Split '-'


### PR DESCRIPTION
Pull the SID directly from the 'krbtgt' user to avoid errors in ConvertTo-SID

This produces the SID from the 'krbtgt' user just as the following:

`$ForestSid = (New-Object System.Security.Principal.NTAccount($ForestObject.RootDomain.Name,"krbtgt")).Translate([System.Security.Principal.SecurityIdentifier]).Value
$Parts = $ForestSid -Split "-"
$ForestSid = $Parts[0..$($Parts.length-2)] -join "-"`