### PR TITLE
Added [string] to fix $matches

### DIFF
--- a/Exfiltration/Get-TimedScreenshot.ps1
+++ b/Exfiltration/Get-TimedScreenshot.ps1
@@ -55,7 +55,7 @@ https://github.com/mattifestation/PowerSploit/blob/master/Exfiltration/Get-Timed
 
        $VideoController = Get-WmiObject -Query 'SELECT VideoModeDescription FROM Win32_VideoController'
 
-       if ($VideoController.VideoModeDescription -and $VideoController.VideoModeDescription -match '(?<ScreenWidth>^\d+) x (?<ScreenHeight>\d+) x .*$') {
+       if ($VideoController.VideoModeDescription -and [String] $VideoController.VideoModeDescription -match '(?<ScreenWidth>^\d+) x (?<ScreenHeight>\d+) x .*$') {
            $Width = [Int] $Matches['ScreenWidth']
            $Height = [Int] $Matches['ScreenHeight']
        } else {


### PR DESCRIPTION
I have tested the dev version of the script and spotted an error. In short, $object with -match returns $null. Strings must be compared to resolve the issue.

More details are on http://stackoverflow.com/questions/8651905/powershell-match-operator-returns-true-but-matches-is-null. 