### PR TITLE
The DFS subfunctions only accept a single $Domain

### DIFF
--- a/Recon/PowerView.ps1
+++ b/Recon/PowerView.ps1
@@ -9915,7 +9915,7 @@ function Get-DomainDFSShare {
 .SYNOPSIS
 
 Returns a list of all fault-tolerant distributed file systems
-for the current (or specified) domain.
+for the current (or specified) domains.
 
 Author: Ben Campbell (@meatballs__)  
 License: BSD 3-Clause  
@@ -9930,7 +9930,7 @@ The server data is parsed appropriately and returned.
 
 .PARAMETER Domain
 
-Specifies the domain to use for the query, defaults to the current domain.
+Specifies the domains to use for the query, defaults to the current domain.
 
 .PARAMETER SearchBase
 
@@ -10213,7 +10213,7 @@ A custom PSObject describing the distributed file systems.
         function Get-DomainDFSShareV1 {
             [CmdletBinding()]
             Param(
-                [String[]]
+                [String]
                 $Domain,
 
                 [String]
@@ -10292,7 +10292,7 @@ A custom PSObject describing the distributed file systems.
         function Get-DomainDFSShareV2 {
             [CmdletBinding()]
             Param(
-                [String[]]
+                [String]
                 $Domain,
 
                 [String]


### PR DESCRIPTION
Specifying the type as an array of strings results in an error when passing on the parameter to `Get-DomainSearcher`:

    C:\> Get-DomainDFSShare -Domain test
    Get-DomainSearcher : Cannot process argument transformation on parameter 'Domain'. Cannot convert value to type System.String.
    At PowerView.ps1:10242 char:46

This appears to have been introduced during the massive rewrite. Previously the `Get-DFSshare` function did not support multiple domains. Now the top-level function does, but it iterates through the array and passes each domain individually to the version specific subfunctions.