### PR TITLE
Script Import Fails, fixed parameter name issues in New-ADObjectAccessControlEntry

### DIFF
--- a/Recon/PowerView.ps1
+++ b/Recon/PowerView.ps1
@@ -6634,19 +6634,19 @@ System.Security.AccessControl.AuthorizationRule
         [ValidateSet('AccessSystemSecurity', 'CreateChild','Delete','DeleteChild','DeleteTree','ExtendedRight','GenericAll','GenericExecute','GenericRead','GenericWrite','ListChildren','ListObject','ReadControl','ReadProperty','Self','Synchronize','WriteDacl','WriteOwner','WriteProperty')]
         $Right,
 
-        [Parameter(Mandatory = $True, ParameterSetName=’AccessRuleType’)]
+        [Parameter(Mandatory = $True, ParameterSetName='AccessRuleType')]
         [ValidateSet('Allow', 'Deny')]
         [String[]]
         $AccessControlType,
 
-        [Parameter(Mandatory = $True, ParameterSetName=’AuditRuleType’)]
+        [Parameter(Mandatory = $True, ParameterSetName='AuditRuleType')]
         [ValidateSet('Success', 'Failure')]
         [String]
         $AuditFlag,
 
-        [Parameter(Mandatory = $False, ParameterSetName=’AccessRuleType’)]
-        [Parameter(Mandatory = $False, ParameterSetName=’AuditRuleType’)]
-        [Parameter(Mandatory = $False, ParameterSetName=’ObjectGuidLookup’)]
+        [Parameter(Mandatory = $False, ParameterSetName='AccessRuleType')]
+        [Parameter(Mandatory = $False, ParameterSetName='AuditRuleType')]
+        [Parameter(Mandatory = $False, ParameterSetName='ObjectGuidLookup')]
         [Guid]
         $ObjectType,
 


### PR DESCRIPTION
- Import Fails
- Error is in New-ADObjectAccessControlEntry
- Fixed parameter name
~~~~ 
Error Message:
At C:\Users\Home\Desktop\PowerView.ps1:6637 char:56
+         [Parameter(Mandatory = $True, ParameterSetName=â€™AccessRuleT ...
+                                                        ~
Missing statement after '=' in named argument.
At C:\Users\Home\Desktop\PowerView.ps1:6637 char:56
+         [Parameter(Mandatory = $True, ParameterSetName=â€™AccessRuleT ...
+                                                        ~
Missing closing ')' in expression.
At C:\Users\Home\Desktop\PowerView.ps1:6642 char:56
+         [Parameter(Mandatory = $True, ParameterSetName=â€™AuditRuleTy ...
+                                                        ~
Missing statement after '=' in named argument.
At C:\Users\Home\Desktop\PowerView.ps1:6642 char:56
+         [Parameter(Mandatory = $True, ParameterSetName=â€™AuditRuleTy ...
+                                                        ~
Missing closing ')' in expression.
At C:\Users\Home\Desktop\PowerView.ps1:6647 char:57
+         [Parameter(Mandatory = $False, ParameterSetName=â€™AccessRule ...
+                                                         ~
Missing statement after '=' in named argument.
At C:\Users\Home\Desktop\PowerView.ps1:6647 char:57
+         [Parameter(Mandatory = $False, ParameterSetName=â€™AccessRule ...
+                                                         ~
Missing closing ')' in expression.
At C:\Users\Home\Desktop\PowerView.ps1:6648 char:57
+         [Parameter(Mandatory = $False, ParameterSetName=â€™AuditRuleT ...
+                                                         ~
Missing statement after '=' in named argument.
At C:\Users\Home\Desktop\PowerView.ps1:6648 char:57
+         [Parameter(Mandatory = $False, ParameterSetName=â€™AuditRuleT ...
+                                                         ~
Missing closing ')' in expression.
At C:\Users\Home\Desktop\PowerView.ps1:6649 char:57
+         [Parameter(Mandatory = $False, ParameterSetName=â€™ObjectGuid ...
+                                                         ~
Missing statement after '=' in named argument.
At C:\Users\Home\Desktop\PowerView.ps1:6649 char:57
+         [Parameter(Mandatory = $False, ParameterSetName=â€™ObjectGuid ...
+                                                         ~
Missing closing ')' in expression.
Not all parse errors were reported.  Correct the reported errors and try again.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : MissingExpressionInNamedArgument
~~~~ 