### PR TITLE
Bug fixes

### DIFF
--- a/Privesc/PowerUp.ps1
+++ b/Privesc/PowerUp.ps1
@@ -3681,22 +3681,24 @@ function Get-CachedGPPPassword {
                $Password += , $DecryptedPassword
            }
             
-            # put [BLANK] in variables
-            if (-not $Password) {$Password = '[BLANK]'}
-            if (-not $UserName) {$UserName = '[BLANK]'}
-            if (-not $Changed)  {$Changed = '[BLANK]'}
-            if (-not $NewName)  {$NewName = '[BLANK]'}
-                  
-            # Create custom object to output results
-            $ObjectProperties = @{'Passwords' = $Password;
-                                  'UserNames' = $UserName;
-                                  'Changed' = $Changed;
-                                  'NewName' = $NewName;
-                                  'File' = $File}
-                
-            $ResultsObject = New-Object -TypeName PSObject -Property $ObjectProperties
-            Write-Verbose "The password is between {} and may be more than one value."
-            if ($ResultsObject) {Return $ResultsObject} 
+           if ($Password -or $UserName -or $Changed -or $NewName) {
+                # put [BLANK] in variables
+                if (-not $Password) {$Password = '[BLANK]'}
+                if (-not $UserName) {$UserName = '[BLANK]'}
+                if (-not $Changed)  {$Changed = '[BLANK]'}
+                if (-not $NewName)  {$NewName = '[BLANK]'}
+                    
+                # Create custom object to output results
+                $ObjectProperties = @{'Passwords' = $Password;
+                                    'UserNames' = $UserName;
+                                    'Changed' = $Changed;
+                                    'NewName' = $NewName;
+                                    'File' = $File}
+                    
+                $ResultsObject = New-Object -TypeName PSObject -Property $ObjectProperties
+                Write-Verbose "The password is between {} and may be more than one value."
+                if ($ResultsObject) {Return $ResultsObject}
+           }
         }
 
         catch {Write-Error $Error[0]}

--- a/Privesc/PowerUp.ps1
+++ b/Privesc/PowerUp.ps1
@@ -996,16 +996,19 @@ function Get-CurrentUserTokenGroupSid {
             For ($i=0; $i -lt $TokenGroups.GroupCount; $i++) {
                 # convert each token group SID to a displayable string
                 $SidString = ''
-                $Result = $Advapi32::ConvertSidToStringSid($TokenGroups.Groups[$i].SID, [ref]$SidString);$LastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-                if($Result -eq 0) {
-                    Write-Verbose "Error: $(([ComponentModel.Win32Exception] $LastError).Message)"
-                }
-                else {
-                    $GroupSid = New-Object PSObject
-                    $GroupSid | Add-Member Noteproperty 'SID' $SidString
-                    # cast the atttributes field as our SidAttributes enum
-                    $GroupSid | Add-Member Noteproperty 'Attributes' ($TokenGroups.Groups[$i].Attributes -as $SidAttributes)
-                    $GroupSid
+                if ($TokenGroups.Groups[$i].SID -and $TokenGroups.Groups[$i].SID -ne '')
+                {
+                    $Result = $Advapi32::ConvertSidToStringSid($TokenGroups.Groups[$i].SID, [ref]$SidString);$LastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+                    if($Result -eq 0) {
+                        Write-Verbose "Error: $(([ComponentModel.Win32Exception] $LastError).Message)"
+                    }
+                    else {
+                        $GroupSid = New-Object PSObject
+                        $GroupSid | Add-Member Noteproperty 'SID' $SidString
+                        # cast the atttributes field as our SidAttributes enum
+                        $GroupSid | Add-Member Noteproperty 'Attributes' ($TokenGroups.Groups[$i].Attributes -as $SidAttributes)
+                        $GroupSid
+                    }
                 }
             }
         }

--- a/Privesc/PowerUp.ps1
+++ b/Privesc/PowerUp.ps1
@@ -853,7 +853,7 @@ function Get-ModifiablePath {
                     # if the path doesn't exist, check if the parent folder allows for modification
                     try {
                         $ParentPath = Split-Path $TempPath -Parent
-                        if($ParentPath -and (Test-Path -Path $ParentPath)) {
+                        if ($ParentPath -and ($ParentPath -ne '') -and ($ParentPath -ne '\') -and (Test-Path -Path $ParentPath )) {
                             $CandidatePaths += Resolve-Path -Path $ParentPath -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Path
                         }
                     }
@@ -880,7 +880,7 @@ function Get-ModifiablePath {
                                     # if the path doesn't exist, check if the parent folder allows for modification
                                     try {
                                         $ParentPath = (Split-Path -Path $TempPath -Parent).Trim()
-                                        if($ParentPath -and ($ParentPath -ne '') -and (Test-Path -Path $ParentPath )) {
+                                        if ($ParentPath -and ($ParentPath -ne '') -and ($ParentPath -ne '\') -and (Test-Path -Path $ParentPath )) {
                                             $CandidatePaths += Resolve-Path -Path $ParentPath | Select-Object -ExpandProperty Path
                                         }
                                     }


### PR DESCRIPTION
I found a few cases that were not handled and either produced false positives or did not handle an exception.

Get-ModifiablePath treats service parameters like paths causing c:\ to be reported as writable.  It also did not handle System.UnauthorizedAccessException.  There is still a false positive for services that take a parameter for a writable path to write data to.

Get-CurrentUserTokenGroupSid tries to use empty SID values causing exceptions.

local:Get-GPPInnerFields reports xml files that have no credentials.  Added check to not emit result in this case.