### PR TITLE
PowerUp.ps1:883,1458 - Remove "C:\" False Positives

### DIFF
--- a/Privesc/PowerUp.ps1
+++ b/Privesc/PowerUp.ps1
@@ -880,7 +880,7 @@ function Get-ModifiablePath {
                                     # if the path doesn't exist, check if the parent folder allows for modification
                                     try {
                                         $ParentPath = (Split-Path -Path $TempPath -Parent).Trim()
-                                        if($ParentPath -and ($ParentPath -ne '') -and (Test-Path -Path $ParentPath )) {
+                                        if($ParentPath -and ($ParentPath -ne '','C:\') -and (Test-Path -Path $ParentPath )) {
                                             $CandidatePaths += Resolve-Path -Path $ParentPath | Select-Object -ExpandProperty Path
                                         }
                                     }
@@ -1455,7 +1455,7 @@ function Get-ServiceUnquoted {
 
             $ModifiableFiles = $Service.pathname.split(' ') | Get-ModifiablePath
 
-            $ModifiableFiles | Where-Object {$_ -and $_.ModifiablePath -and ($_.ModifiablePath -ne '')} | Foreach-Object {
+            $ModifiableFiles | Where-Object -filterscript {$_ -and $_.ModifiablePath -and ($_.ModifiablePath -ne '') -and -not ($_.ModifiablePath.EndsWith('C:\'))} | Foreach-Object {
                 $ServiceRestart = Test-ServiceDaclPermission -PermissionSet 'Restart' -Name $Service.name
 
                 if($ServiceRestart) {


### PR DESCRIPTION
By default, the C:\ folder has special permissions set that allow unprivileged users to create new folders, but not to create or modify files in C:\ . This special premission set is misinterpreted by the script as a writable folder in the path, even though it is not. The proposed change removes results that return C:\ (subfolders within C:\ are still returned if they are modifiable).