### PR TITLE
PowerUp.ps1:1507 - Remove dllhost args

### DIFF
--- a/Privesc/PowerUp.ps1
+++ b/Privesc/PowerUp.ps1
@@ -1504,7 +1504,7 @@ function Get-ModifiableServiceFile {
     Get-WMIObject -Class win32_service | Where-Object {$_ -and $_.pathname} | ForEach-Object {
 
         $ServiceName = $_.name
-        $ServicePath = $_.pathname
+        $ServicePath = $_.pathname.split("/")[0]
         $ServiceStartName = $_.startname
 
         $ServicePath | Get-ModifiablePath | ForEach-Object {


### PR DESCRIPTION
The original instantiation of this line of code would cause errors with dllhost.exe /ProccessId:{...} arg (normally hidden by the -ErrorActionPreference = "SilentlyContinue" flag). The proposed change strips these args, allowing the remaining value to be evaluated by the script vice skipping over it due to an error.