### PR TITLE
PowerUp.ps1:2850 - Filter Out Null/Blank Output

### DIFF
--- a/Privesc/PowerUp.ps1
+++ b/Privesc/PowerUp.ps1
@@ -2847,7 +2847,7 @@ function Get-ModifiableRegistryAutoRun {
 
             $Path = $($Keys.GetValue($Name))
 
-            $Path | Get-ModifiablePath | ForEach-Object {
+            $Path | where-Object $_ -contains '\' | Get-ModifiablePath | ForEach-Object {
                 $Out = New-Object PSObject
                 $Out | Add-Member Noteproperty 'Key' "$ParentPath\$Name"
                 $Out | Add-Member Noteproperty 'Path' $Path


### PR DESCRIPTION
Added "where-Object $_ -contains '\'" to prevent null or blank output from being passed to Get-ModifiablePath