### PR TITLE
PowerUp.ps1:880 - Remove "C:\" False Positives

### DIFF
--- a/Privesc/PowerUp.ps1
+++ b/Privesc/PowerUp.ps1
@@ -877,7 +877,7 @@ a modifiable path.
                                     # if the path doesn't exist, check if the parent folder allows for modification
                                     try {
                                         $ParentPath = (Split-Path -Path $TempPath -Parent -ErrorAction SilentlyContinue).Trim()
-                                        if ($ParentPath -and ($ParentPath -ne '') -and (Test-Path -Path $ParentPath  -ErrorAction SilentlyContinue)) {
+                                        if ($ParentPath -and ($ParentPath -ne '','C:\') -and (Test-Path -Path $ParentPath  -ErrorAction SilentlyContinue)) {
                                             $CandidatePaths += Resolve-Path -Path $ParentPath -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Path
                                         }
                                     }


### PR DESCRIPTION
By default, the C:\ folder has special permissions set that allow unprivileged users to create new folders, but not to create or modify files in C:\ . This special permission set is misinterpreted by the script as a writable folder in the path, even though it is not. The proposed change removes results that return C:\ (subfolders within C:\ are still returned if they are modifiable).