### PR TITLE
PowerUp.ps1:3158 - Check SystemPath only

### DIFF
--- a/Privesc/PowerUp.ps1
+++ b/Privesc/PowerUp.ps1
@@ -3155,7 +3155,7 @@ http://www.greyhathacker.net/?p=738
     Param()
 
     # use -Literal so the spaces in %PATH% folders are not tokenized
-    Get-Item Env:Path | Select-Object -ExpandProperty Value | ForEach-Object { $_.split(';') } | Where-Object {$_ -and ($_ -ne '')} | ForEach-Object {
+     (get-itemproperty "HKLM:\System\CurrentControlSet\Control\Session Manager\Environment").path.split(';') | ForEach-Object {
         $TargetPath = $_
         $ModifidablePaths = $TargetPath | Get-ModifiablePath -Literal | Where-Object {$_ -and ($Null -ne $_) -and ($Null -ne $_.ModifiablePath) -and ($_.ModifiablePath.Trim() -ne '')}
         ForEach ($ModifidablePath in $ModifidablePaths) {


### PR DESCRIPTION
The current instantiation of code calls the %PATH% environment variable. However, since PowerUp is normally run with the permissions of an unprivileged crappy user in order to privesc, the %PATH% variable is returned as a concatenation of the SystemPath and UserPath. Any exploitable services running as SYSTEM will not call DLLs from the UserPath. Thus, we need to focus on writable folders in the SystemPath only in order to privesc. The proposed change pulls the SystemPath value directly from the registry and places it in the same format as the original code.