### PR TITLE
Fix Get-NetSession

### DIFF
--- a/Recon/PowerView.ps1
+++ b/Recon/PowerView.ps1
@@ -15009,9 +15009,11 @@ http://www.powershellmagazine.com/2014/09/25/easily-defining-enums-structs-and-w
             $EntriesRead = 0
             $TotalRead = 0
             $ResumeHandle = 0
-
+            #Null username first prior to passing to NetSessionEnum API
+            $UserName = ''
+            
             # get session information
-            $Result = $Netapi32::NetSessionEnum($Computer, '', $UserName, $QueryLevel, [ref]$PtrInfo, -1, [ref]$EntriesRead, [ref]$TotalRead, [ref]$ResumeHandle)
+            $Result = $Netapi32::NetSessionEnum($ComputerName, '', $UserName, $QueryLevel, [ref]$PtrInfo, -1, [ref]$EntriesRead, [ref]$TotalRead, [ref]$ResumeHandle)
 
             # locate the offset of the initial intPtr
             $Offset = $PtrInfo.ToInt64()


### PR DESCRIPTION
Fixes Computer typo to ComputerName in NetSessionEnum, null out user first prior to passing.

This might be due to the way user hunting is, if that is I can create a switch to return all, as this is useful in internal host recon to determine all logged on users from a non-privileged account along with HKU.