### PR TITLE
Add additional search entry for 'Get-UnattendedInstallFile'

### DIFF
--- a/Privesc/PowerUp.ps1
+++ b/Privesc/PowerUp.ps1
@@ -3710,6 +3710,7 @@ Finds any remaining unattended installation files.
 .LINK
 
 http://www.fuzzysecurity.com/tutorials/16.html
+https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/windows-setup-automation-overview
 
 .OUTPUTS
 
@@ -3745,6 +3746,14 @@ Custom PSObject containing results.
         $Out.PSObject.TypeNames.Insert(0, 'PowerUp.UnattendedInstallFile')
         $Out
     }
+    
+    # test the existence of the unattend file entry in the registry 
+    $RegValue = (Get-ItemProperty -Path HKLM:\SYSTEM\Setup -Name UnattendFile).UnattendFile
+    $Out = New-Object PSObject
+    $Out | Add-Member Noteproperty 'UnattendPath' $RegValue
+    $Out | Add-Member Aliasproperty Name UnattendPath
+    $Out.PSObject.TypeNames.Insert(0, 'PowerUp.UnattendedInstallFile')
+    $Out
 
     $ErrorActionPreference = $OrigError
 }


### PR DESCRIPTION
Based on the following [Microsoft Article](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/windows-setup-automation-overview), under the Implicit Answer File Search Order section, an additional location for an answer file may exist at HKLM\SYSTEM\Setup\UnattendFile. As pointed in the article, the full path to the file is stored under the aforementioned registry key. The file does not need to be named as Unattend.xml or the like, and can be located anywhere on the drive.