### PR TITLE
[Fix] Memory leak with CSList::ThrowAll() in NTFS_Common.h

### DIFF
--- a/Exfiltration/NTFSParser/NTFSParser/NTFS_Common.h
+++ b/Exfiltration/NTFSParser/NTFSParser/NTFS_Common.h
@@ -220,6 +220,15 @@ public:
 	// Caution! All entries are just thrown without free
 	__inline void ThrowAll()
 	{
+		// Must free NTSLIST_ENTRY because InsertEntry() doesn't copy this pointer
+		while (ListHead)
+		{
+			ListCurrent = ListHead->Next;
+			ListHead->Entry = NULL;
+			delete ListHead;
+
+			ListHead = ListCurrent;
+		}
 		ListHead = ListTail = NULL;
 		ListCurrent = NULL;
 		EntryCount = 0;

--- a/Exfiltration/NTFSParser/NTFSParserDLL/NTFS_Common.h
+++ b/Exfiltration/NTFSParser/NTFSParserDLL/NTFS_Common.h
@@ -220,6 +220,15 @@ public:
 	// Caution! All entries are just thrown without free
 	__inline void ThrowAll()
 	{
+		// Must free NTSLIST_ENTRY because InsertEntry() doesn't copy this pointer
+		while (ListHead)
+		{
+			ListCurrent = ListHead->Next;
+			ListHead->Entry = NULL;
+			delete ListHead;
+
+			ListHead = ListCurrent;
+		}
 		ListHead = ListTail = NULL;
 		ListCurrent = NULL;
 		EntryCount = 0;


### PR DESCRIPTION
Hi,
Here is my fix for isssue #268 
