### PR TITLE
Prevent constraint violation on objects with restrictive permissions

### DIFF
--- a/Recon/PowerView.ps1
+++ b/Recon/PowerView.ps1
@@ -3629,7 +3629,14 @@ function Add-ObjectAcl {
                         # add all the new ACEs to the specified object
                         ForEach ($ACE in $ACEs) {
                             Write-Verbose "Granting principal $ResolvedPrincipalSID '$($ACE.ObjectType)' rights on $($_.Properties.distinguishedname)"
+                            # resolve the object
                             $Object = [adsi]($_.path)
+                            
+                            # restrict object changes to ACL only
+                            [System.DirectoryServices.DirectoryEntryConfiguration]$SecOptions = $Object.get_Options()
+                            $SecOptions.SecurityMasks = [System.DirectoryServices.SecurityMasks]’Dacl’
+                            
+                            # add ACE
                             $Object.PsBase.ObjectSecurity.AddAccessRule($ACE)
                             $Object.PsBase.commitchanges()
                         }


### PR DESCRIPTION
This change restricts access to ADSI object so they're only writting to the ACL.
This fixes an issue writting an ACL when you exclusively have `WriteDacl` permission on a object.


I have run up against this issue in a pentest where it meant I wasn't able to get to DA, but didn't know what was going on. I also came up against it in a HtB machine, so I had time to debug the tool and see what was going on.

This was an issue because if you don't set the security mask to `Dacl`, it will attempt to write the whole object back to LDAP instead of just the ACE. If you only have `WriteDacl` on the object, this will obviously fail.

This change has been tested against a HtB machine, and successfully wrote DCSync privs where the current master failed.