### PR TITLE
Update PowerView.ps1

### DIFF
--- a/Recon/PowerView.ps1
+++ b/Recon/PowerView.ps1
@@ -2233,7 +2233,7 @@ filter Get-NetDomain {
         }
     }
     else {
-        [System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain()
+        [System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain()
     }
 }
 


### PR DESCRIPTION
GetCurrentUserDomain encounter with:
Exception calling "GetCurrentUserDomain" with "0" argument(s): "Current security context is not associated with an Active
Directory domain or forest."
At line:1 char:1
+ [System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain()
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : ActiveDirectoryOperationException

In updated windows and .Net framework now but when changing to GetcomputerDomain while we have logged in with a domain user the problem will be resolved.